### PR TITLE
Only close automatically if autoclose is set

### DIFF
--- a/lightpick.js
+++ b/lightpick.js
@@ -575,7 +575,7 @@
             }
             while ((parentEl = parentEl.parentNode));
 
-            if (self.isShowing && target !== opts.field && parentEl !== opts.field) {
+            if (self.isShowing && opts.autoclose && target !== opts.field && parentEl !== opts.field) {
                 self.hide();
             }
         };


### PR DESCRIPTION
The issue currently is that if you have `autoclose` set to `false` the calendar will still close if you clicked outside of the field/parent element which messes up, especially when you have a range picker and you haven't picked the dates correctly.

Adding this will prevent the calendar from closing.