### PR TITLE
Added onSelectStart and onSelectEnd helper functions to detect when selection was started and when it was ended

### DIFF
--- a/css/lightpick.css
+++ b/css/lightpick.css
@@ -149,7 +149,6 @@
 .lightpick__day {
     display: flex;
     height: 40px;
-    border: 0;
     background-position: center center;
     background-size: contain;
     background-repeat: no-repeat;

--- a/css/lightpick.css
+++ b/css/lightpick.css
@@ -149,6 +149,7 @@
 .lightpick__day {
     display: flex;
     height: 40px;
+    border: 0;
     background-position: center center;
     background-size: contain;
     background-repeat: no-repeat;

--- a/lightpick.js
+++ b/lightpick.js
@@ -256,17 +256,12 @@
             day.className.splice(day.className.indexOf('is-available'), 1);
         }
 
-        var dateEl = document.createElement('div');
-        if (opts.inline) {
-            // Changing date element to a "button" for inline calendar for accessibility
-            dateEl = document.createElement('button');
-            dateEl.setAttribute('type', 'button');
-        }
-        dateEl.className = day.className.join(' ');
-        dateEl.innerHTML = date.get('date');
-        dateEl.setAttribute('data-time', day.time);
+        var div = document.createElement('div');
+        div.className = day.className.join(' ');
+        div.innerHTML = date.get('date');
+        div.setAttribute('data-time', day.time);
 
-        return dateEl.outerHTML;
+        return div.outerHTML;
     },
 
     renderMonthsList = function(date, opts)

--- a/lightpick.js
+++ b/lightpick.js
@@ -85,6 +85,10 @@
         },
 
         onSelect: null,
+        // Callback applicable only for date range selection
+        onSelectStart: null,
+        // Callback applicable only for date range selection
+        onSelectEnd: null,
         onOpen: null,
         onClose: null,
         onError: null,
@@ -1098,6 +1102,9 @@
             if (!preventOnSelect && typeof this._opts.onSelect === 'function') {
                 this._opts.onSelect.call(this, this.getStartDate(), this.getEndDate());
             }
+            if (!preventOnSelect && !this._opts.singleDate && typeof this._opts.onSelectStart === 'function') {
+                this._opts.onSelectStart.call(this, this.getStartDate());
+            }
         },
 
         setEndDate: function(date, preventOnSelect)
@@ -1129,6 +1136,9 @@
 
             if (!preventOnSelect && typeof this._opts.onSelect === 'function') {
                 this._opts.onSelect.call(this, this.getStartDate(), this.getEndDate());
+            }
+            if (!preventOnSelect && !this._opts.singleDate && typeof this._opts.onSelectEnd === 'function') {
+                this._opts.onSelectEnd.call(this, this.getEndDate());
             }
         },
 

--- a/lightpick.js
+++ b/lightpick.js
@@ -252,15 +252,20 @@
             day.className.splice(day.className.indexOf('is-available'), 1);
         }
 
-        var div = document.createElement('div');
-        div.className = day.className.join(' ');
-        div.innerHTML = date.get('date');
-        div.setAttribute('data-time', day.time);
+        var dateEl = document.createElement('div');
+        if (opts.inline) {
+            // Changing date element to a "button" for inline calendar for accessibility
+            dateEl = document.createElement('button');
+            dateEl.setAttribute('type', 'button');
+        }
+        dateEl.className = day.className.join(' ');
+        dateEl.innerHTML = date.get('date');
+        dateEl.setAttribute('data-time', day.time);
 
-        return div.outerHTML;
+        return dateEl.outerHTML;
     },
 
-    renderMonthsList = function(date, opts) 
+    renderMonthsList = function(date, opts)
     {
         var d = moment(date),
             select = document.createElement('select');
@@ -280,14 +285,14 @@
         }
 
         select.className = 'lightpick__select lightpick__select-months';
-        
+
         // for text align to right
         select.dir = 'rtl';
 
         if (!opts.dropdowns || !opts.dropdowns.months) {
             select.disabled = true;
         }
-    
+
         return select.outerHTML;
     },
 
@@ -482,7 +487,7 @@
 
         if (opts.parentEl instanceof Node) {
             opts.parentEl.appendChild(self.el)
-        } 
+        }
         else if (opts.parentEl === 'body' && opts.inline) {
             opts.field.parentNode.appendChild(self.el);
         }
@@ -1207,7 +1212,7 @@
                 }
 
                 this.syncFields();
-                
+
                 if (this._opts.secondField && this._opts.secondField === target && this._opts.endDate) {
                     this.gotoDate(this._opts.endDate);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightpick",
-  "version": "0.0.3",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightpick",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightpick",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Javascript date range picker - lightweight, no jQuery",
   "main": "lightpick.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightpick",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "Javascript date range picker - lightweight, no jQuery",
   "main": "lightpick.js",
   "scripts": {


### PR DESCRIPTION
Added ``onSelectStart`` and ``onSelectEnd`` helper methods to detect when selection was started when it was ended. This was added to handle the use case where developer would want control over how he wants to set a date range. For example:

1. I have an external button "set date" which sets the current selected date range to a destination. I want to disable "set date" button on "select start" and re-enable it on "select end". Hence, the helpers ``onSelectStart`` and ``onSelectEnd``.