### PR TITLE
 Changed month and year to text to improve styling

### DIFF
--- a/css/lightpick.css
+++ b/css/lightpick.css
@@ -95,7 +95,7 @@
     z-index: 9999;
 }
 
-.lightpick__label > .lightpick__label-month {
+.lightpick__label-month {
     font-weight: bold;
     font-size: 1em;
     margin-right: .5em;

--- a/css/lightpick.css
+++ b/css/lightpick.css
@@ -74,19 +74,28 @@
     border-radius: 4px;
 }
 
-.lightpick__month-title > .lightpick__select {
-    border: none;
-    background-color: transparent;
-    outline: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
-}
-.lightpick__month-title > .lightpick__select:disabled {
+.lightpick__label > select:disabled {
     color: #333;
 }
 
-.lightpick__month-title > .lightpick__select-months {
+.lightpick__label > select {
+    opacity: 0;
+    position: absolute;
+    left: 0;
+    top: 5px;
+    margin: 0;
+    cursor: pointer;
+    z-index: 9998;
+}
+
+.lightpick__label {
+    overflow: hidden;
+    display: inline-block;
+    position: relative;
+    z-index: 9999;
+}
+
+.lightpick__label > .lightpick__label-month {
     font-weight: bold;
     font-size: 1em;
     margin-right: .5em;

--- a/css/lightpick.css
+++ b/css/lightpick.css
@@ -88,7 +88,7 @@
     z-index: 9998;
 }
 
-.lightpick__label {
+.lightpick__month-title > .lightpick__label {
     overflow: hidden;
     display: inline-block;
     position: relative;

--- a/lightpick.js
+++ b/lightpick.js
@@ -283,7 +283,7 @@
         }
 
         div.className = 'lightpick__label';
-        span.className = 'lightpick__label lightpick__label-month';
+        span.className = 'lightpick__label-month';
         select.className = 'lightpick__select lightpick__select-months';
 
         if (!opts.dropdowns || !opts.dropdowns.months) {
@@ -330,7 +330,7 @@
         }
 
         div.className = 'lightpick__label';
-        span.className = 'lightpick__label lightpick__label-year';
+        span.className = 'lightpick__label-year';
         select.className = 'lightpick__select lightpick__select-years';
 
         if (!opts.dropdowns || !opts.dropdowns.years) {

--- a/lightpick.js
+++ b/lightpick.js
@@ -263,6 +263,8 @@
     renderMonthsList = function(date, opts) 
     {
         var d = moment(date),
+            div = document.createElement('div'),
+            span = document.createElement('span'),
             select = document.createElement('select');
 
         for (var idx = 0; idx < 12; idx++) {
@@ -274,27 +276,32 @@
 
             if (idx === date.toDate().getMonth()) {
                 option.setAttribute('selected', 'selected');
+                span.innerText = option.text;
             }
 
             select.appendChild(option);
         }
 
+        div.className = 'lightpick__label';
+        span.className = 'lightpick__label lightpick__label-month';
         select.className = 'lightpick__select lightpick__select-months';
-        
-        // for text align to right
-        select.dir = 'rtl';
 
         if (!opts.dropdowns || !opts.dropdowns.months) {
             select.disabled = true;
         }
+        
+        div.appendChild(span);
+        div.appendChild(select);
     
-        return select.outerHTML;
+        return div.outerHTML;
     },
 
     renderYearsList = function(date, opts)
     {
         var d = moment(date),
+            div = document.createElement('div'),
             select = document.createElement('select'),
+            span = document.createElement('span'),
             years = opts.dropdowns && opts.dropdowns.years ? opts.dropdowns.years : null,
             minYear = years && years.min ? years.min : 1900,
             maxYear = years && years.max ? years.max : Number.parseInt(moment().format('YYYY'));
@@ -316,18 +323,24 @@
 
             if (idx === date.toDate().getFullYear()) {
                 option.setAttribute('selected', 'selected');
+                span.innerText = option.text;
             }
 
             select.appendChild(option);
         }
 
+        div.className = 'lightpick__label';
+        span.className = 'lightpick__label lightpick__label-year';
         select.className = 'lightpick__select lightpick__select-years';
 
         if (!opts.dropdowns || !opts.dropdowns.years) {
             select.disabled = true;
         }
 
-        return select.outerHTML;
+        div.appendChild(span);
+        div.appendChild(select);
+
+        return div.outerHTML;
     },
 
     renderCalendar = function(el, opts)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@phantom2005/lightpick",
-  "version": "1.3.6",
+  "name": "lightpick",
+  "version": "1.3.4",
   "description": "Javascript date range picker - lightweight, no jQuery",
   "main": "lightpick.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lightpick",
-  "version": "1.3.4",
+  "name": "@phantom2005/lightpick",
+  "version": "1.3.6",
   "description": "Javascript date range picker - lightweight, no jQuery",
   "main": "lightpick.js",
   "scripts": {


### PR DESCRIPTION
I was having some styling issues in my project with Lightpick.
Month and year were aligned to the right inside the select element which is not ideal if you want to add your own custom styling.

Here is an example of what it looks like after my improvement:
``![Image of Improved month and year styling](https://media.giphy.com/media/SruOH6LLQat2UE96iP/giphy.gif)

Thanks in advance for accepting it!