### PR TITLE
return a clone when get date to prevent mutability problems

### DIFF
--- a/lightpick.js
+++ b/lightpick.js
@@ -1167,17 +1167,17 @@
 
         getStartDate: function()
         {
-            return moment(this._opts.startDate).isValid() ? this._opts.startDate : null;
+            return moment(this._opts.startDate).isValid() ? this._opts.startDate.clone() : null;
         },
 
         getEndDate: function()
         {
-            return moment(this._opts.endDate).isValid() ? this._opts.endDate : null;
+            return moment(this._opts.endDate).isValid() ? this._opts.endDate.clone() : null;
         },
 
         getDate: function()
         {
-            return moment(this._opts.startDate).isValid() ? this._opts.startDate : null;
+            return moment(this._opts.startDate).isValid() ? this._opts.startDate.clone() : null;
         },
 
         toString: function(format)


### PR DESCRIPTION
getStartDate, getEndDate and getDate will return a clone instead of this._opts.startDate or this._opts.endDate itself to prevent mutability problems.

<img width="322" alt="when you add 3 month" src="https://user-images.githubusercontent.com/24871430/62587760-f1847980-b8f5-11e9-9549-a8bac4c2b844.png">