### PR TITLE
Fix iOS daylight savings time weekdayName issue

### DIFF
--- a/lightpick.js
+++ b/lightpick.js
@@ -102,7 +102,7 @@
 
     weekdayName = function(opts, day, short)
     {
-        return new Date(1970, 0, day).toLocaleString(opts.lang, { weekday: short ? 'short' : 'long' })
+        return new Date(1970, 0, day, 12, 0, 0, 0).toLocaleString(opts.lang, { weekday: short ? 'short' : 'long' })
     },
 
     renderDay = function(opts, date, dummy, extraClass)


### PR DESCRIPTION
iOS incorrectly backdates daylight savings time to before it was implemented, as well as double-applying the hour offset in NZST.  This has the effect of causing the "day of the week" label to be off-by one, eg 
![image](https://user-images.githubusercontent.com/1063865/65105211-53bdb780-da28-11e9-9046-d065858cfb99.png)

Fix this by using midday instead of midnight for weekday calculations, which can then cope with iOS's buggy handling of daylight savings