### PR TITLE
Fix minDate and maxDate format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+[1.3.5] - 
+* New option `weekdayStyle` - Weekday display style added.
+    Possible values are 'long', 'short' or 'narrow'.
+    Implementation of #91
+
 [1.3.4] - 2019-03-30
 * fixed bug #51
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ Disable Saturday and Sunday.
 
 Show calendar inline. If `true` and `parentEl` is not provided then will use `parentNode` of field.
 
+### weekdayStyle
+- Type: `String`
+- Default: `short`
+
+Determines the weekday display style.
+Possible values are: `long` (e.g., Thursday), `short` (e.g., Thu), `narrow` (e.g., T).
+Two weekdays may have the same narrow style for some locales (e.g. Tuesday's narrow style is also T).
+
 ### dropdowns
 - Type: `Object|Boolean`
 - Default: 

--- a/lightpick.js
+++ b/lightpick.js
@@ -54,6 +54,7 @@
         orientation: 'auto',
         disableWeekends: false,
         inline: false,
+        weekdayStyle: 'short',
         dropdowns: {
             years: {
                 min: 1900,
@@ -100,9 +101,9 @@
             + '</div>';
     },
 
-    weekdayName = function(opts, day, short)
+    weekdayName = function(opts, day, weekdayStyle)
     {
-        return new Date(1970, 0, day).toLocaleString(opts.lang, { weekday: short ? 'short' : 'long' })
+        return new Date(1970, 0, day).toLocaleString(opts.lang, { weekday: weekdayStyle || opts.weekdayStyle });
     },
 
     renderDay = function(opts, date, dummy, extraClass)
@@ -353,7 +354,7 @@
 
             html += '<div class="lightpick__days-of-the-week">';
             for (var w = opts.firstDay + 4; w < 7 + opts.firstDay + 4; ++w) {
-                html += '<div class="lightpick__day-of-the-week" title="' + weekdayName(opts, w) + '">' + weekdayName(opts, w, true) + '</div>';
+                html += '<div class="lightpick__day-of-the-week" title="' + weekdayName(opts, w, 'long') + '">' + weekdayName(opts, w) + '</div>';
             }
             html += '</div>'; // lightpick__days-of-the-week
 

--- a/lightpick.js
+++ b/lightpick.js
@@ -260,7 +260,7 @@
         return div.outerHTML;
     },
 
-    renderMonthsList = function(date, opts) 
+    renderMonthsList = function(date, opts)
     {
         var d = moment(date),
             select = document.createElement('select');
@@ -280,14 +280,14 @@
         }
 
         select.className = 'lightpick__select lightpick__select-months';
-        
+
         // for text align to right
         select.dir = 'rtl';
 
         if (!opts.dropdowns || !opts.dropdowns.months) {
             select.disabled = true;
         }
-    
+
         return select.outerHTML;
     },
 
@@ -482,7 +482,7 @@
 
         if (opts.parentEl instanceof Node) {
             opts.parentEl.appendChild(self.el)
-        } 
+        }
         else if (opts.parentEl === 'body' && opts.inline) {
             opts.field.parentNode.appendChild(self.el);
         }
@@ -872,9 +872,9 @@
                 opts.numberOfColumns = 1;
             }
 
-            opts.minDate = opts.minDate && moment(opts.minDate).isValid() ? moment(opts.minDate) : null;
+            opts.minDate = opts.minDate && moment(opts.minDate, opts.format).isValid() ? moment(opts.minDate, opts.format) : null;
 
-            opts.maxDate = opts.maxDate && moment(opts.maxDate).isValid() ? moment(opts.maxDate) : null;
+            opts.maxDate = opts.maxDate && moment(opts.maxDate, opts.format).isValid() ? moment(opts.maxDate, opts.format) : null;
 
             if (opts.lang === 'auto') {
                 var browserLang = navigator.language || navigator.userLanguage;
@@ -1211,7 +1211,7 @@
                 }
 
                 this.syncFields();
-                
+
                 if (this._opts.secondField && this._opts.secondField === target && this._opts.endDate) {
                     this.gotoDate(this._opts.endDate);
                 }


### PR DESCRIPTION
Lack of format causes the moment library to always returns minDate and maxDate invalid.

Formats added and it's ok now.

Sorry for the prettier also removed some whitespaces.

Thank you.